### PR TITLE
Adds Noto Sans Bold Cut

### DIFF
--- a/heltour/tournament/templates/empty_base.html
+++ b/heltour/tournament/templates/empty_base.html
@@ -8,7 +8,7 @@
     <title>{% block title %}{{ league.name }}{% endblock %}</title>
 
     {% load staticfiles tournament_extras %}
-    <link href="https://fonts.googleapis.com/css?family=Noto+Sans" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Noto+Sans:400,700" rel="stylesheet">
     <link rel="shortcut icon" type="image/png" href="{% block iconpath %}{% static 'tournament/img/favicon.png' %}{% endblock %}?v={{ static_version }}"/>
     {% block common_css %}
     <link href="{% static "lib/css/bootstrap.min.css" %}?v={{ static_version }}" rel="stylesheet">


### PR DESCRIPTION
Hi,
This adds the bold cut of the Noto Sans Webfont.
It should make things like table headers look much nicer and consistent in every browser.
Thanks
/sgis