### PR TITLE
Fix baste url for those without a bitbucket account

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ icalendar==4.0.4
 pillow==6.2.1
 pyfcm==1.3.1
 letsencrypt
--e git+git@bitbucket.org:strabs/baste.git#egg=baste
+-e git+https://bitbucket.org/strabs/baste.git#egg=baste


### PR DESCRIPTION
The "git@" version requires a ssh key set up for bitbucket.