### PR TITLE
Allow player presences to be seen by everyone

### DIFF
--- a/heltour/local/sebbers.py
+++ b/heltour/local/sebbers.py
@@ -1,6 +1,7 @@
 DEBUG = True
 GOOGLE_SERVICE_ACCOUNT_KEYFILE_PATH = '/home/lakin/work/development/heltour/gspread.conf'
 SLACK_API_TOKEN_FILE_PATH = '/home/lakin/work/development/heltour/slack-token.conf'
+SLACK_WEBHOOK_FILE_PATH = '/home/lakin/personal-repos/lichess/heltour/webhook.txt'
 
 INTERNAL_IPS = ['127.0.0.1', '192.168.1.19']
-JAVAFO_COMMAND = 'java -jar /home/lakin/personal-repos/heltour/javafo.jar'
+JAVAFO_COMMAND = 'java -jar /home/lakin/personal-repos/lichess/heltour/javafo.jar'

--- a/heltour/local/trunkie.py
+++ b/heltour/local/trunkie.py
@@ -1,7 +1,7 @@
 DEBUG = True
 GOOGLE_SERVICE_ACCOUNT_KEYFILE_PATH = '/home/lakin/personal-repos/heltour/gspread.conf'
 SLACK_API_TOKEN_FILE_PATH = '/home/lakin/personal-repos/heltour/slack-token.txt'
-SLACK_WEBHOOK_FILE_PATH = '/home/lakin/personal-repos/heltour/slack-webhook.txt'
+SLACK_WEBHOOK_FILE_PATH = '/home/lakin/personal-repos/lichess/heltour/webhook.txt'
 
 INTERNAL_IPS = ['127.0.0.1', '192.168.1.19']
 JAVAFO_COMMAND = 'java -jar /home/lakin/personal-repos/heltour/javafo.jar'

--- a/heltour/tournament/views.py
+++ b/heltour/tournament/views.py
@@ -440,10 +440,7 @@ class PairingsView(SeasonView):
         else:
             return self.lone_view(round_number, team_number)
 
-    def _player_status(self, player, pairing, presences, in_contact_period, contact_deadline,
-                       can_view_precenses):
-        if not can_view_precenses:
-            return (None, None)
+    def _player_status(self, player, pairing, presences, in_contact_period, contact_deadline):
         pres = presences.get((player.pk, pairing.pk))
         if in_contact_period:
             if not pres or not pres.first_msg_time:
@@ -500,8 +497,7 @@ class PairingsView(SeasonView):
                 pairing,
                 presences,
                 in_contact_period,
-                contact_deadline,
-                can_change_pairing
+                contact_deadline
             )
 
         # Add presences
@@ -623,8 +619,7 @@ class PairingsView(SeasonView):
                 pairing,
                 presences,
                 in_contact_period,
-                contact_deadline,
-                can_change_pairing
+                contact_deadline
             )
 
         # Add errors


### PR DESCRIPTION
This was discussed some time ago, but I can't find an exact ticket. But player presences are public info as far as the mods are concerned, so this shows it all the time.