### PR TITLE
Fix the space before player's rating in team profile page

### DIFF
--- a/heltour/tournament/templates/tournament/team_profile.html
+++ b/heltour/tournament/templates/tournament/team_profile.html
@@ -22,8 +22,9 @@
                                         {% if team_member %}
                                             <a href="{% leagueurl 'player_profile' league.tag season.tag team_member.player.lichess_username %}">
                                                 {{ team_member.player.lichess_username }}
-                                                        {% if team_member.player_rating_display %} (
-                                                            {{ team_member.player_rating_display }}){% endif %}
+                                                        {% if team_member.player_rating_display %}
+                                                            ({{ team_member.player_rating_display }})
+                                                        {% endif %}
                                             </a>
                                         {% endif %}
                                     </td>


### PR DESCRIPTION
Example of the wrong formatting, https://www.lichess4545.com/team4545/season/27/team/35/

Board 1: | My_goal_2400 ( 2202)

There's a space before 2202.