### PR TITLE
fix https://github.com/cyanfish/heltour/issues/405 - correct initial population of offset choice field

### DIFF
--- a/heltour/tournament/forms.py
+++ b/heltour/tournament/forms.py
@@ -467,7 +467,7 @@ class NotificationsForm(forms.Form):
                                   (30, '30 minutes'), (60, '1 hour'), (120, '2 hours')]
                 self.fields[type_ + '_offset'] = forms.TypedChoiceField(choices=offset_options,
                                                                         initial=int(
-                                                                            setting.offset.total_seconds()) / 60,
+                                                                            setting.offset.total_seconds() / 60),
                                                                         coerce=int)
 
 


### PR DESCRIPTION
by making sure that the setting is read as int to match the comparison
with the offset_options